### PR TITLE
Improve memory usage, fix molecule bugs

### DIFF
--- a/nvidia/cheminformatics/utils/logger.py
+++ b/nvidia/cheminformatics/utils/logger.py
@@ -73,6 +73,8 @@ class MetricsLogger(object):
         if self.metric_value is None:
             self.metric_name = ''
             self.metric_value = ''
+        else:
+            logger.info('Calculated {} is {}'.format(self.metric_name, self.metric_value))
 
         log_results(self.start_time, context.compute_type, self.task_name,
                     runtime,

--- a/nvidia/cheminformatics/utils/plot_benchmark_results.py
+++ b/nvidia/cheminformatics/utils/plot_benchmark_results.py
@@ -114,7 +114,8 @@ def prepare_benchmark_df(benchmark_file, step_type_dict=STEP_TYPE_DICT, step_typ
     # Standardize columns for output
     bench_time_df_output = bench_time_df.copy().round(2)
     columns = bench_time_df_output.columns.get_level_values('step').to_list()
-    bench_time_df_output.columns = pd.Categorical(columns, categories=['n_molecules', 'benchmark_type', 'n_workers'] + columns, ordered=True)
+    bench_time_df_output.columns = pd.Categorical(
+        columns, categories=['n_molecules', 'benchmark_type', 'n_workers'] + columns, ordered=True)
 
     basename = os.path.splitext(benchmark_file)[0]
     with pd.ExcelWriter(basename + '.xlsx') as writer:
@@ -147,7 +148,6 @@ def prepare_acceleration_stacked_plot(df, machine_config, output_path, palette=N
         axList = [axList]
     else:
         axList = axList.flatten()
-
 
     df_plot = df[('stats', 'total')].reset_index(
         level='n_molecules').pivot(columns='n_molecules')
@@ -194,5 +194,5 @@ if __name__ == '__main__':
 
     # Read and prepare the dataframe then plot
     bench_df, machine_config = prepare_benchmark_df(benchmark_file=args.benchmark_file, step_type_dict=STEP_TYPE_DICT,
-                                    step_type_cat=STEP_TYPE_CAT)
+                                                    step_type_cat=STEP_TYPE_CAT)
     prepare_acceleration_stacked_plot(bench_df, machine_config, output_path=args.output_path)

--- a/nvidia/cheminformatics/wf/cluster/__init__.py
+++ b/nvidia/cheminformatics/wf/cluster/__init__.py
@@ -32,7 +32,7 @@ class BaseClusterWorkflow:
 
         return embedding, prop_series
 
-    def _random_sample_from_arrays(self, input_array_list, n_samples=None, index=None):
+    def _random_sample_from_arrays(self, *input_array_list, n_samples=None, index=None):
         assert (n_samples is not None) != (index is not None)  # XOR -- must specify one or the other, but not both
 
         # Ensure array sizes are all the same
@@ -60,6 +60,9 @@ class BaseClusterWorkflow:
                 output_array_list[pos] = array.iloc[index]
             else:
                 output_array_list[pos] = array[index]
+
+        if len(output_array_list) == 1:
+            output_array_list = output_array_list[0]
 
         return output_array_list, index
 

--- a/nvidia/cheminformatics/wf/cluster/__init__.py
+++ b/nvidia/cheminformatics/wf/cluster/__init__.py
@@ -21,7 +21,7 @@ class BaseClusterWorkflow:
     def _remove_non_numerics(self, embedding):
         embedding = self._remove_ui_columns(embedding)
 
-        other_props = ['id'] +  IMP_PROPS + ADDITIONAL_FEILD
+        other_props = ['id'] + IMP_PROPS + ADDITIONAL_FEILD
         # Tempraryly store columns not required during processesing
         prop_series = {}
         for col in other_props:
@@ -32,19 +32,43 @@ class BaseClusterWorkflow:
 
         return embedding, prop_series
 
+    def _random_sample_from_arrays(self, input_array_list, n_samples=None, index=None):
+        assert (n_samples is not None) != (index is not None)  # XOR -- must specify one or the other, but not both
 
-    def _compute_spearman_rho(self, embedding, X_train, Xt):
-        n_indexes = min(self.n_spearman, X_train.shape[0])
-        numpy.random.seed(self.seed)
-        indexes = numpy.random.choice(numpy.array(range(X_train.shape[0])),
-                                      size=n_indexes,
-                                      replace=False)
-        fp_sample = embedding.compute().values[indexes]
-        Xt_sample = Xt.compute().values[indexes]
+        # Ensure array sizes are all the same
+        sizes = []
+        output_array_list = []
+        for array in input_array_list:
+            if hasattr(array, 'compute'):
+                array = array.compute()
+            sizes.append(array.shape[0])
+            output_array_list.append(array)
 
+        assert all([x == sizes[0] for x in sizes])
+        size = sizes[0]
+
+        if index is not None:
+            assert (index.max() < size) & (len(index) <= size)
+        else:
+            # Sample from data / shuffle
+            n_samples = min(size, n_samples)
+            numpy.random.seed(self.seed)
+            index = numpy.random.choice(numpy.arange(size), size=n_samples, replace=False)
+
+        for pos, array in enumerate(output_array_list):
+            if hasattr(array, 'values'):
+                output_array_list[pos] = array.iloc[index]
+            else:
+                output_array_list[pos] = array[index]
+
+        return output_array_list, index
+
+    def _compute_spearman_rho(self, fp_sample, Xt_sample, top_k=100):
+        if hasattr(fp_sample, 'values'):
+            fp_sample = fp_sample.values
         dist_array_tani = tanimoto_calculate(fp_sample, calc_distance=True)
         dist_array_eucl = pairwise_distances(Xt_sample)
-        return cupy.nanmean(spearmanr(dist_array_tani, dist_array_eucl, top_k=100))
+        return cupy.nanmean(spearmanr(dist_array_tani, dist_array_eucl, top_k=top_k))
 
     def is_gpu_enabled(self):
         return True
@@ -66,7 +90,7 @@ class BaseClusterWorkflow:
         """
         NotImplemented
 
-    def add_molecules(self, chemblids:List):
+    def add_molecules(self, chemblids: List):
         """
         ChembleId's accepted as argument to the existing database. Duplicates
         must be ignored.

--- a/nvidia/cheminformatics/wf/cluster/cpukmeansumap.py
+++ b/nvidia/cheminformatics/wf/cluster/cpukmeansumap.py
@@ -16,10 +16,11 @@
 
 import logging
 from nvidia.cheminformatics.data.helper.chembldata import ADDITIONAL_FEILD, IMP_PROPS
-from nvidia.cheminformatics.config import Context
 
-import sklearn.decomposition
+from dask_ml.decomposition import PCA as dask_PCA
 from dask_ml.cluster import KMeans as dask_KMeans
+import dask.array
+# import sklearn.decomposition
 import umap
 import numpy
 import cupy
@@ -31,14 +32,16 @@ from nvidia.cheminformatics.utils.distance import tanimoto_calculate
 from nvidia.cheminformatics.data import ClusterWfDAO
 from nvidia.cheminformatics.data.cluster_wf import ChemblClusterWfDao
 from nvidia.cheminformatics.utils.logger import MetricsLogger
+from nvidia.cheminformatics.config import Context
 
 
 logger = logging.getLogger(__name__)
 
+
 class CpuKmeansUmap(BaseClusterWorkflow):
 
     def __init__(self,
-                 n_molecules = None,
+                 n_molecules=None,
                  dao: ClusterWfDAO = ChemblClusterWfDao(),
                  n_pca=64,
                  n_clusters=7,
@@ -49,37 +52,25 @@ class CpuKmeansUmap(BaseClusterWorkflow):
         self.n_clusters = n_clusters
 
         self.seed = seed
+        self.context = Context()
         self.n_spearman = 5000
+        self.n_silhouette = 500000
 
     def is_gpu_enabled(self):
         return False
 
-    def _compute_spearman_rho(self, mol_df, X_train):
-        n_indexes = min(self.n_spearman, X_train.shape[0])
-        numpy.random.seed(self.seed)
-        indexes = numpy.random.choice(numpy.array(range(X_train.shape[0])),
-                                      size=n_indexes,
-                                      replace=False)
-
-        fp_sample = cupy.array(mol_df.iloc[indexes])
-        Xt_sample = cupy.array(X_train[indexes])
-
-        dist_array_tani = tanimoto_calculate(fp_sample, calc_distance=True)
-        dist_array_eucl = pairwise_distances(Xt_sample)
-        return cupy.nanmean(spearmanr(dist_array_tani, dist_array_eucl, top_k=100))
-
     def cluster(self,
                 df_molecular_embedding=None):
         logger.info("Executing CPU workflow...")
-        cache_directory = Context().cache_directory
+        cache_directory = self.context.cache_directory
 
         if df_molecular_embedding is None:
-            self.n_molecules = Context().n_molecule
+            self.n_molecules = self.context.n_molecule
             df_molecular_embedding = self.dao.fetch_molecular_embedding(
                 self.n_molecules,
                 cache_directory=cache_directory)
 
-        ids =  df_molecular_embedding['id']
+        ids = df_molecular_embedding['id']
         df_molecular_embedding = df_molecular_embedding.persist()
         self.n_molecules = df_molecular_embedding.compute().shape[0]
 
@@ -93,39 +84,45 @@ class CpuKmeansUmap(BaseClusterWorkflow):
         if self.n_pca:
             with MetricsLogger('pca', self.n_molecules) as ml:
 
-                pca = sklearn.decomposition.PCA(n_components=self.n_pca)
-                df_fingerprints = pca.fit_transform(df_molecular_embedding)
+                # pca = sklearn.decomposition.PCA(n_components=self.n_pca) # TODO ask Rajesh why this is used
+                pca = dask_PCA(n_components=self.n_pca)
+                df_fingerprints = pca.fit_transform(df_molecular_embedding.to_dask_array(lengths=True))
 
         else:
-            df_fingerprints = df_molecular_embedding.copy()
+            df_fingerprints = df_molecular_embedding.copy()  # TODO is copy required here?
 
         with MetricsLogger('kmeans', self.n_molecules,) as ml:
 
             kmeans_float = dask_KMeans(n_clusters=self.n_clusters)
             kmeans_float.fit(df_fingerprints)
-            kmeans_labels = kmeans_float.predict(df_fingerprints)
+            kmeans_labels = kmeans_float.labels_
 
             ml.metric_name = 'silhouette_score'
             ml.metric_func = batched_silhouette_scores
-            ml.metric_func_args = (df_fingerprints, kmeans_labels)
-            ml.metric_func_kwargs = {'on_gpu': False, 'seed': self.seed}
+            ml.metric_func_kwargs = {}
+            ml.metric_func_args = (None, None)
+            if self.context.is_benchmark:
+                (df_fingerprints_sample, kmeans_labels_sample), _ = self._random_sample_from_arrays(
+                    [df_fingerprints, kmeans_labels], n_samples=self.n_silhouette)
+                ml.metric_func_args = (df_fingerprints_sample, kmeans_labels_sample)
 
         with MetricsLogger('umap', self.n_molecules) as ml:
-            umap_model = umap.UMAP()
-
+            umap_model = umap.UMAP()  # TODO: Use dask to distribute umap. https://github.com/dask/dask/issues/5229
             X_train = umap_model.fit_transform(df_fingerprints)
-            # TODO: Use dask to distribute umap. https://github.com/dask/dask/issues/5229
-            # Sample to calculate spearman's rho
-            # Currently this converts indexes to
-            df_molecular_embedding = df_molecular_embedding.compute()
+            X_train = dask.array.from_array(X_train)
+            # df_molecular_embedding = df_molecular_embedding.compute()
 
             ml.metric_name = 'spearman_rho'
             ml.metric_func = self._compute_spearman_rho
-            ml.metric_func_args = (df_molecular_embedding, X_train)
+            ml.metric_func_args = (None, None)
+            if self.context.is_benchmark:
+                (df_molecular_embedding_sample, X_train_sample), _ = self._random_sample_from_arrays(
+                    [df_molecular_embedding, X_train], n_samples=self.n_spearman)
+                ml.metric_func_args = (df_molecular_embedding_sample, X_train_sample)
 
         df_molecular_embedding['x'] = X_train[:, 0]
         df_molecular_embedding['y'] = X_train[:, 1]
-        df_molecular_embedding['cluster'] = kmeans_float.labels_
+        df_molecular_embedding['cluster'] = kmeans_labels
         df_molecular_embedding['id'] = ids
 
         self.df_embedding = df_molecular_embedding

--- a/nvidia/cheminformatics/wf/cluster/gpukmeansumap.py
+++ b/nvidia/cheminformatics/wf/cluster/gpukmeansumap.py
@@ -81,7 +81,9 @@ class GpuKmeansUmap(BaseClusterWorkflow, metaclass=Singleton):
 
         self.df_embedding = None
         self.seed = seed
+        self.context = Context()
         self.n_spearman = 5000
+        self.n_silhouette = 500000
 
     def _cluster(self, embedding, n_pca):
         """
@@ -89,33 +91,44 @@ class GpuKmeansUmap(BaseClusterWorkflow, metaclass=Singleton):
         molecular fingerprints.
         """
 
-        dask_client = Context().dask_client
+        dask_client = self.context.dask_client
         embedding = embedding.reset_index()
-        n_molecules = embedding.compute().shape[0]
 
         # Before reclustering remove all columns that may interfere
         embedding, prop_series = self._remove_non_numerics(embedding)
+        n_molecules, n_obs = embedding.compute().shape
 
-        if n_pca and embedding.shape[1] > n_pca:
+        # if self.context.is_benchmark:
+        #     [molecular_embedding], sample_indexes = self._random_sample_from_arrays([embedding], n_samples=self.n_silhouette)
+
+        if n_pca and n_obs > n_pca:
             with MetricsLogger('pca', n_molecules) as ml:
                 if self.pca == None:
                     self.pca = cuDaskPCA(client=dask_client, n_components=n_pca)
                     self.pca.fit(embedding)
+                df_molecular_embedding = embedding.copy()
                 embedding = self.pca.transform(embedding)
+        else:
+            df_molecular_embedding = embedding
 
         with MetricsLogger('kmeans', n_molecules) as ml:
             if n_molecules < MIN_RECLUSTER_SIZE:
-                raise Exception('Reclustering less then %d molecules is not supported.' % MIN_RECLUSTER_SIZE)
+                raise Exception('Reclustering less than %d molecules is not supported.' % MIN_RECLUSTER_SIZE)
 
             kmeans_cuml = cuDaskKMeans(client=dask_client,
-                                    n_clusters=self.n_clusters)
+                                       n_clusters=self.n_clusters)
             kmeans_cuml.fit(embedding)
             kmeans_labels = kmeans_cuml.predict(embedding)
 
             ml.metric_name = 'silhouette_score'
             ml.metric_func = batched_silhouette_scores
-            ml.metric_func_args = (embedding, kmeans_labels)
-            ml.metric_func_kwargs = {'on_gpu': True,  'seed': self.seed}
+            ml.metric_func_kwargs = {}
+            ml.metric_func_args = (None, None)
+
+            if self.context.is_benchmark:
+                (embedding_sample, kmeans_labels_sample), _ = self._random_sample_from_arrays(
+                    [embedding, kmeans_labels], n_samples=self.n_silhouette)
+                ml.metric_func_args = (embedding_sample, kmeans_labels_sample)
 
         with MetricsLogger('umap', n_molecules) as ml:
             X_train = embedding.compute()
@@ -133,7 +146,11 @@ class GpuKmeansUmap(BaseClusterWorkflow, metaclass=Singleton):
 
             ml.metric_name = 'spearman_rho'
             ml.metric_func = self._compute_spearman_rho
-            ml.metric_func_args = (embedding, X_train, Xt)
+            ml.metric_func_args = (None, None)
+            if self.context.is_benchmark:
+                (df_molecular_embedding_sample, X_train_sample), _ = self._random_sample_from_arrays(
+                    [df_molecular_embedding, X_train], n_samples=self.n_spearman)
+                ml.metric_func_args = (df_molecular_embedding_sample, X_train_sample)
 
         # Add back the column required for plotting and to correlating data
         # between re-clustering
@@ -152,11 +169,11 @@ class GpuKmeansUmap(BaseClusterWorkflow, metaclass=Singleton):
         logger.info("Executing GPU workflow...")
 
         if df_mol_embedding is None:
-            self.n_molecules = Context().n_molecule
+            self.n_molecules = self.context.n_molecule
 
             df_mol_embedding = self.dao.fetch_molecular_embedding(
                 self.n_molecules,
-                cache_directory=Context().cache_directory)
+                cache_directory=self.context.cache_directory)
 
             df_mol_embedding = df_mol_embedding.persist()
 
@@ -184,7 +201,7 @@ class GpuKmeansUmap(BaseClusterWorkflow, metaclass=Singleton):
 
         return self.df_embedding
 
-    def add_molecules(self, chemblids:List):
+    def add_molecules(self, chemblids: List):
 
         chem_mol_map = {row[0]: row[1] for row in self.dao.fetch_id_from_chembl(chemblids)}
         molregnos = list(chem_mol_map.keys())

--- a/nvidia/cheminformatics/wf/cluster/gpurandomprojection.py
+++ b/nvidia/cheminformatics/wf/cluster/gpurandomprojection.py
@@ -82,6 +82,8 @@ class GpuWorkflowRandomProjection(BaseClusterWorkflow, metaclass=Singleton):
         self.n_clusters = n_clusters
         self.pca = None
         self.seed = seed
+        self.n_silhouette = 500000
+        self.context = Context()
         self.srp_embedding = SparseRandomProjection(n_components=2)
 
     def rand_jitter(self, arr):
@@ -114,8 +116,12 @@ class GpuWorkflowRandomProjection(BaseClusterWorkflow, metaclass=Singleton):
 
             ml.metric_name = 'silhouette_score'
             ml.metric_func = batched_silhouette_scores
-            ml.metric_func_args = (srp, kmeans_labels)
-            ml.metric_func_kwargs = {'on_gpu': True,  'seed': self.seed}
+            ml.metric_func_kwargs = {}
+            ml.metric_func_args = (None, None)
+            if self.context.is_benchmark:
+                (srp_sample, kmeans_labels_sample), _ = self._random_sample_from_arrays(
+                    [srp, kmeans_labels], n_samples=self.n_silhouette)
+                ml.metric_func_args = (srp_sample, kmeans_labels_sample)
 
         # Add back the column required for plotting and to correlating data
         # between re-clustering
@@ -134,11 +140,11 @@ class GpuWorkflowRandomProjection(BaseClusterWorkflow, metaclass=Singleton):
         logger.info("Executing GPU workflow...")
 
         if df_mol_embedding is None:
-            self.n_molecules = Context().n_molecule
+            self.n_molecules = self.context.n_molecule
 
             df_mol_embedding = self.dao.fetch_molecular_embedding(
                 self.n_molecules,
-                cache_directory=Context().cache_directory)
+                cache_directory=self.context.cache_directory)
             df_mol_embedding = df_mol_embedding.persist()
 
         self.df_embedding = _gpu_random_proj_wrapper(df_mol_embedding, self)
@@ -159,7 +165,7 @@ class GpuWorkflowRandomProjection(BaseClusterWorkflow, metaclass=Singleton):
         self.df_embedding = _gpu_random_proj_wrapper(self.df_embedding, self)
         return self.df_embedding
 
-    def add_molecules(self, chemblids:List):
+    def add_molecules(self, chemblids: List):
 
         chem_mol_map = {row[0]: row[1] for row in self.dao.fetch_id_from_chembl(chemblids)}
         molregnos = list(chem_mol_map.keys())

--- a/nvidia/cheminformatics/wf/cluster/gpurandomprojection.py
+++ b/nvidia/cheminformatics/wf/cluster/gpurandomprojection.py
@@ -120,7 +120,7 @@ class GpuWorkflowRandomProjection(BaseClusterWorkflow, metaclass=Singleton):
             ml.metric_func_args = (None, None)
             if self.context.is_benchmark:
                 (srp_sample, kmeans_labels_sample), _ = self._random_sample_from_arrays(
-                    [srp, kmeans_labels], n_samples=self.n_silhouette)
+                    srp, kmeans_labels, n_samples=self.n_silhouette)
                 ml.metric_func_args = (srp_sample, kmeans_labels_sample)
 
         # Add back the column required for plotting and to correlating data

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -33,14 +33,15 @@ logger = logging.getLogger(__name__)
 
 
 # Parameter lists
-run_benchmark_params = [ ([{'test_type': 'nvidia.cheminformatics.wf.cluster.gpukmeansumap.GpuKmeansUmap',
-                            'use_gpu': True,
-                            'n_workers':  1,
-                            'n_mol': 5000},
-                           {'test_type': 'nvidia.cheminformatics.wf.cluster.cpukmeansumap.CpuKmeansUmap',
-                            'use_gpu': False,
-                            'n_workers': 10,
-                            'n_mol': 5000}]) ]
+run_benchmark_params = [([{'test_type': 'nvidia.cheminformatics.wf.cluster.gpukmeansumap.GpuKmeansUmap',
+                           'use_gpu': True,
+                           'n_workers':  1,
+                           'n_mol': 5000},
+                          {'test_type': 'nvidia.cheminformatics.wf.cluster.cpukmeansumap.CpuKmeansUmap',
+                           'use_gpu': False,
+                           'n_workers': 10,
+                           'n_mol': 5000}])]
+
 
 @pytest.mark.parametrize('benchmark_config_list', run_benchmark_params)
 def test_run_benchmark(benchmark_config_list):
@@ -101,6 +102,3 @@ def test_run_benchmark(benchmark_config_list):
     png_file = basename + '.png'
     prepare_acceleration_stacked_plot(df, machine_config, output_path=png_file)
     assert os.path.exists(png_file)
-
-
-# TODO add test for metrics and values


### PR DESCRIPTION
This PR accomplished the following:

Bugs Fixed
• GPU Workflow: Calculation of Tanimoto distance for SpearmanR was using PCA-generated embeddings rather than Morgan Fingerprints, causing a NaN value. Now correctly using Morgan Fingerprints.
• Number of molecules is now correctly counted in GPU workflow logging when set to -1 (all molecules)

Improvements
• Memory requirements are improved by only storing input arrays for metrics when benchmarking, and when stored, they are pre-sampled 
• Pre-sampling of arrays allowed metric calculations to be streamlined