### PR TITLE
Bugfix: CPU Clustering workflow failure from UI...

### DIFF
--- a/nvidia/cheminformatics/data/cluster_wf.py
+++ b/nvidia/cheminformatics/data/cluster_wf.py
@@ -1,6 +1,5 @@
-from nvidia.cheminformatics.config import Context
-from nvidia.cheminformatics.utils.singleton import Singleton
 import os
+import math
 import cudf
 import dask_cudf
 import dask
@@ -11,7 +10,9 @@ from contextlib import closing
 from typing import List
 
 from . import ClusterWfDAO
-from nvidia.cheminformatics.data.helper.chembldata import ChEmblData
+from nvidia.cheminformatics.data.helper.chembldata import BATCH_SIZE, ChEmblData
+from nvidia.cheminformatics.config import Context
+from nvidia.cheminformatics.utils.singleton import Singleton
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,8 @@ class ChemblClusterWfDao(ClusterWfDAO, metaclass=Singleton):
             mol_df = dask.dataframe.read_hdf(hdf_path, 'fingerprints')
 
             if n_molecules > 0:
-                mol_df = mol_df.head(n_molecules, compute=False, npartitions=-1)
+                npartitions = math.ceil(n_molecules / BATCH_SIZE)
+                mol_df = mol_df.head(n_molecules, compute=False, npartitions=npartitions)
         else:
             logger.info('Reading molecules from database...')
             mol_df = chem_data.fetch_mol_embedding(num_recs=n_molecules)

--- a/nvidia/cheminformatics/data/helper/chembldata.py
+++ b/nvidia/cheminformatics/data/helper/chembldata.py
@@ -47,6 +47,8 @@ ADDITIONAL_FEILD_TYPE = [pandas.Series([], dtype='object'),
                          pandas.Series([], dtype='object')]
 
 
+BATCH_SIZE = 5000
+
 # DEPRECATED. Please add code to DAO classes.
 class ChEmblData(object, metaclass=Singleton):
 
@@ -206,7 +208,7 @@ class ChEmblData(object, metaclass=Singleton):
 
     def fetch_mol_embedding(self,
                             num_recs=None,
-                            batch_size=5000,
+                            batch_size=BATCH_SIZE,
                             molregnos=None,
                             **transformation_kwargs):
         """

--- a/nvidia/cheminformatics/interactive/chemvisualize.py
+++ b/nvidia/cheminformatics/interactive/chemvisualize.py
@@ -169,12 +169,11 @@ class ChemVisualization:
                                  gradient_prop=gradient_prop,
                                  north_stars=north_stars)
 
-    def create_graph(self, df, color_col='cluster', north_stars=None, gradient_prop=None):
+    def create_graph(self, ldf, color_col='cluster', north_stars=None, gradient_prop=None):
         fig = go.Figure(layout={'colorscale': {}})
 
-        ldf = df
-        if hasattr(df, 'compute'):
-            ldf = df.compute()
+        if hasattr(ldf, 'compute'):
+            ldf = ldf.compute()
 
         moi_molregno = []
         if north_stars:
@@ -396,7 +395,7 @@ class ChemVisualization:
                                         options=[{'label': 'Gpu KmeansUmap', 'value': 'nvidia.cheminformatics.wf.cluster.gpukmeansumap.GpuKmeansUmap'},
                                                  {'label': 'GPU Random Projection - Single GPU', 'value': 'nvidia.cheminformatics.wf.cluster.gpurandomprojection.GpuWorkflowRandomProjection'},
                                                  {'label': 'Cpu KmeansUmap', 'value': 'nvidia.cheminformatics.wf.cluster.cpukmeansumap.CpuKmeansUmap'},],
-                                        value='alogp',
+                                        value=self.wf,
                                         clearable=False),
                         ], className='nine columns'),
                         dbc.Button('Apply',

--- a/nvidia/cheminformatics/wf/cluster/__init__.py
+++ b/nvidia/cheminformatics/wf/cluster/__init__.py
@@ -80,7 +80,7 @@ class BaseClusterWorkflow:
         """
         Runs clustering workflow on the data fetched from database/cache.
         """
-        NotImplemented
+        raise NotImplementedError
 
     def recluster(self,
                   filter_column=None,
@@ -91,14 +91,14 @@ class BaseClusterWorkflow:
         The new dataframe is usually a subset of the original dataframe.
         Caller may ask to include additional molecules.
         """
-        NotImplemented
+        raise NotImplementedError
 
     def add_molecules(self, chemblids: List):
         """
         ChembleId's accepted as argument to the existing database. Duplicates
         must be ignored.
         """
-        NotImplemented
+        raise NotImplementedError
 
     def compute_qa_matric(self):
         """

--- a/startdash.py
+++ b/startdash.py
@@ -230,7 +230,7 @@ To create cache:
                                      n_clusters=args.num_clusters)
         else:
             workflow = CpuKmeansUmap(n_molecules=n_molecules,
-                                     n_pca=args.pca_comps,
+                                     pca_comps=args.pca_comps,
                                      n_clusters=args.num_clusters)
 
         mol_df = workflow.cluster()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,12 +3,26 @@ import logging
 
 from tests.utils import _fetch_chembl_test_dataset, _create_context
 
+from nvidia.cheminformatics.wf.cluster.cpukmeansumap import CpuKmeansUmap
 from nvidia.cheminformatics.wf.cluster.gpukmeansumap import GpuKmeansUmap
 from nvidia.cheminformatics.wf.cluster.gpurandomprojection import GpuWorkflowRandomProjection
 from nvidia.cheminformatics.data.helper.chembldata import ChEmblData
 
 
 logger = logging.getLogger(__name__)
+
+
+def test_cpukmeansumap():
+    """
+    Verify fetching data from chemblDB when the input is a pandas df.
+    """
+    n_molecules, dao, mol_df = _fetch_chembl_test_dataset(n_molecules=10000)
+
+    context = _create_context()
+    wf = CpuKmeansUmap(n_molecules=n_molecules,
+                       dao=dao, pca_comps=64)
+    embedding = wf.cluster(df_molecular_embedding=mol_df)
+    logger.info(embedding.head())
 
 
 def test_random_proj():


### PR DESCRIPTION
CPU UMAP modules accepts dash, but the returns np.array. In this type conversion metadata, index and partition information is lost. Though there are ways to rebuild most of this lost information, but doing this accross two datastructure and maintaining relationship is complex and costly.

This change removes dash dataframe during UMAP computation.

Other changes include:
- Raising exceptions from unimplemented method
- Pass number of partition(s) while fetching head of a dask array to avoid loading the entire cache.