### PR TITLE
Rilango/bug n cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ RUN mkdir -p /opt/nvidia/ \
     && rm -rf /opt/nvidia/cheminfomatics/.git
 
 ENV UCX_LOG_LEVEL error
+EXPOSE 5000
 
 CMD cd /opt/nvidia/cheminfomatics; /opt/nvidia/cheminfomatics/launch.sh dash

--- a/nvidia/cheminformatics/interactive/chemvisualize.py
+++ b/nvidia/cheminformatics/interactive/chemvisualize.py
@@ -966,8 +966,9 @@ class ChemVisualization(metaclass=Singleton):
         moi_molregno = None
         _refresh_moi_prop_table = dash.no_update
 
-        if selected_clusters and comp_id == 'bt_recluster_clusters' and event_type == 'n_clicks':
-            filter_values = list(map(int, selected_clusters.split(",")))
+        if comp_id == 'bt_recluster_clusters' and event_type == 'n_clicks':
+            if selected_clusters:
+                filter_values = list(map(int, selected_clusters.split(",")))
             filter_column = 'cluster'
         elif selected_points and comp_id == 'bt_recluster_points' and event_type == 'n_clicks':
             filter_values = []


### PR DESCRIPTION
Changing the 'number of cluster' and reclustering did not pass the new value of
'number of cluster'. This patch unblocks the event to pass the new value to
workflow class.