### PR TITLE
Bugfix: Run with multiple radii were ignoring all but first radius

### DIFF
--- a/benchmark/cuchembm/data/cache.py
+++ b/benchmark/cuchembm/data/cache.py
@@ -97,7 +97,14 @@ class MoleculeGenerator():
 
         new_sample_db = False
         with closing(self.conn.cursor()) as cursor:
-            recs = cursor.execute('SELECT count(*) from smiles').fetchone()
+            recs = cursor.execute('''
+                SELECT count(*) from smiles s
+                WHERE s.model_name = ?
+                    AND s.scaled_radius = ?
+                    AND s.force_unique = ?
+                    AND s.sanitize = ?
+                ''',
+                [self.inferrer.__class__.__name__, scaled_radius, force_unique, sanitize]).fetchone()
             if recs[0] == 0:
                 new_sample_db = True
 


### PR DESCRIPTION
Before importing all SMILES to be used for benchmark, a db query was
used to check if the import was required, to avoid importing the same
dataset multiple times. This query was a placeholder that needed
refinement.