### PR TITLE
Some change to google drive is preventing CDDD model download

### DIFF
--- a/cddd/download_default_model.sh
+++ b/cddd/download_default_model.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 fileid="1oyknOulq_j0w9kzOKKIHdTLo5HphT99h"
 filename="default_model.zip"
-curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}" > /dev/null
+curl -c ./cookie -s -L "https://drive.google.com/file/d/${fileid}iew" > /dev/null
 curl -Lb ./cookie "https://drive.google.com/uc?export=download&confirm=t&id=${fileid}" -o ${filename}
 unzip default_model.zip


### PR DESCRIPTION
This fixes the original download script from CDDD repo