### PR TITLE
Stale GPG Key in CUCHEM base docker file

### DIFF
--- a/Dockerfile.cuchem
+++ b/Dockerfile.cuchem
@@ -1,6 +1,10 @@
 # Copyright 2020 NVIDIA Corporation
 FROM rapidsai/rapidsai:21.08-cuda11.2-runtime-ubuntu20.04-py3.7
 
+# Needed due to https://github.com/NVIDIA/cheminformatics/issues/163
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y wget git unzip tmux \


### PR DESCRIPTION
Fixes issue https://github.com/NVIDIA/cheminformatics/issues/163.

When attempting to build the containers you get this issue building cuchem
```
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease' is not signed.
```

It seems related to [this issue](https://github.com/NVIDIA/nvidia-container-toolkit/issues/257), about NVIDIA rotating their gpg keys.
One can either remove the sources.list or possibly upgrade the base container.
